### PR TITLE
Peer Dependency for Hyperapp

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "uglify-js": "^2.7.5",
     "hyperapp": "^0.12.0"
   },
+  "peerDependencies": {
+    "hyperapp": "^0.12.0"
+  },
   "author": "Wolfgang Wedemeyer <wolf@okwolf.com>",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Using the same version as the devDependencies/tests for now. I'm not sure if this mixin is compatible with earlier versions. Also not sure if we should future proof this by using `"hyperapp": ">=0.12.0"`.