### PR TITLE
Hooks API Refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,20 +18,22 @@
     "build": "npm run bundle && npm run minify",
     "bundle": "rollup -i src/index.js -o dist/logger.js -m -f umd -n logger",
     "minify": "uglifyjs dist/logger.js -o dist/logger.js --mangle --compress warnings=false -p relative --source-map dist/logger.js.map",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "format": "prettier --semi false --write '{src,test}/**/*.js'"
   },
   "babel": {
     "presets": "es2015"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.24.1",
+    "hyperapp": "alpha",
     "jest": "^20.0.4",
+    "prettier": "^1.7.2",
     "rollup": "^0.45.2",
-    "uglify-js": "^2.7.5",
-    "hyperapp": "^0.12.0"
+    "uglify-js": "^2.7.5"
   },
   "peerDependencies": {
-    "hyperapp": "^0.12.0"
+    "hyperapp": "alpha"
   },
   "author": "Wolfgang Wedemeyer <wolf@okwolf.com>",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -6,10 +6,7 @@ function log(prevState, action, nextState) {
   console.groupEnd()
 }
 
-export default function(options) {
-  options = options || {}
-  options.log = typeof options.log === "function" ? options.log : log
-
+function onStateUpdate(callback) {
   return function() {
     return function(action) {
       return function(result) {
@@ -17,11 +14,11 @@ export default function(options) {
           return update(function(prevState) {
             if (typeof result === "function") {
               return result(function(updateResult) {
-                options.log(prevState, action, updateResult)
+                callback(prevState, action, updateResult)
                 return updateResult
               })
             } else {
-              options.log(prevState, action, result)
+              callback(prevState, action, result)
               return result
             }
           })
@@ -29,4 +26,11 @@ export default function(options) {
       }
     }
   }
+}
+
+export default function(options) {
+  options = options || {}
+  options.log = typeof options.log === "function" ? options.log : log
+
+  return onStateUpdate(options.log)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,37 +1,32 @@
 function log(prevState, action, nextState) {
-  console.group('%c action', 'color: gray; font-weight: lighter;', action.name);
-  console.log('%c prev state', 'color: #9E9E9E; font-weight: bold;', prevState);
-  console.log('%c data', 'color: #03A9F4; font-weight: bold;', action.data);
-  console.log('%c next state', 'color: #4CAF50; font-weight: bold;', nextState);
-  console.groupEnd();
+  console.group("%c action", "color: gray; font-weight: lighter;", action.name)
+  console.log("%c prev state", "color: #9E9E9E; font-weight: bold;", prevState)
+  console.log("%c data", "color: #03A9F4; font-weight: bold;", action.data)
+  console.log("%c next state", "color: #4CAF50; font-weight: bold;", nextState)
+  console.groupEnd()
 }
 
 export default function(options) {
-  options = options || {};
-  options.log = typeof options.log === 'function' ? options.log : log;
+  options = options || {}
+  options.log = typeof options.log === "function" ? options.log : log
 
-  return function(emit) {
-    var actionStack = [];
-    return {
-      events: {
-        action: function(state, actions, action) {
-          actionStack.push(action);
-        },
-        resolve: function(state, actions, result) {
-          if (typeof result === 'function') {
-            var action = actionStack.pop();
-            return function(update) {
-              return result(function(result) {
-                actionStack.push(action);
-                return update(result);
-              });
-            };
-          }
-        },
-        update: function(state, actions, nextState) {
-          options.log(state, actionStack.pop(), nextState);
+  return function() {
+    return function(action) {
+      return function(result) {
+        return function(update) {
+          return update(function(prevState) {
+            if (typeof result === "function") {
+              return result(function(updateResult) {
+                options.log(prevState, action, updateResult)
+                return updateResult
+              })
+            } else {
+              options.log(prevState, action, result)
+              return result
+            }
+          })
         }
       }
-    };
-  };
+    }
+  }
 }


### PR DESCRIPTION
Preparing for https://github.com/hyperapp/hyperapp/pull/385 by using `hooks` instead of `events`. Not being passed the current `state` anywhere in the curried action functions available resulted in some code indirection. It appears to work, but I'm thinking I might want to make this and some other useful HOF for `hooks` shared code.