### PR TITLE
Log whole slices in next state (another approach)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,10 +45,6 @@ export default function(options) {
                       dispatchedActionStack.push({
                         name: namedspacedName,
                         data: data,
-                        namespace:
-                          namespace.slice(-1) === "."
-                            ? namespace.slice(0, -1)
-                            : namespace,
                         state: state
                       })
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import defaultLog from "./defaultLog"
 
 export default function(options) {
+  var dispatchedActionStack = []
   options = options || {}
   options.log = typeof options.log === "function" ? options.log : defaultLog
 
@@ -13,22 +14,58 @@ export default function(options) {
           var action = actions[name]
           otherActions[name] =
             typeof action === "function"
-              ? function(data) {
-                  return function(state, actions) {
-                    var result = action(data)
-                    result =
-                      typeof result === "function"
-                        ? result(state, actions)
-                        : result
-                    options.log(
-                      state,
-                      { name: namedspacedName, data: data },
-                      result
-                    )
-                    return result
+              ? (function() {
+                  var rename = "_" + name
+
+                  if (!otherActions._logWithUpdatedState) {
+                    otherActions._logWithUpdatedState = function() {
+                      return function(state) {
+                        var dispatchedActionDetails = dispatchedActionStack.pop()
+                        options.log(
+                          dispatchedActionDetails.state,
+                          {
+                            name: dispatchedActionDetails.name,
+                            data: dispatchedActionDetails.data
+                          },
+                          state
+                        )
+                      }
+                    }
                   }
-                }
+
+                  otherActions[rename] = function(data) {
+                    return function(state, actions) {
+                      var result = action(data)
+
+                      result =
+                        typeof result === "function"
+                          ? result(state, actions)
+                          : result
+
+                      dispatchedActionStack.push({
+                        name: namedspacedName,
+                        data: data,
+                        namespace:
+                          namespace.slice(-1) === "."
+                            ? namespace.slice(0, -1)
+                            : namespace,
+                        state: state
+                      })
+
+                      return result
+                    }
+                  }
+
+                  return function(data) {
+                    return function(state, actions) {
+                      var result = actions[rename](data)
+                      actions._logWithUpdatedState()
+                      return result
+                    }
+                  }
+                })()
               : enhanceActions(action, namedspacedName)
+
           return otherActions
         }, {})
       }


### PR DESCRIPTION
This resolves #19 saving currently implemented interface.

One existing test was modified to correspond with new output.